### PR TITLE
Debian conditionals fix

### DIFF
--- a/tasks/install.yaml
+++ b/tasks/install.yaml
@@ -3,13 +3,13 @@
     get_url: 
       url="http://repo.zabbix.com/zabbix/3.0/debian/pool/main/z/zabbix-release/zabbix-release_3.0-1+jessie_all.deb"
       dest="/tmp/zabbix-release_3.0-1.deb"
-    when: ansible_os_family == "Debian" and ansible_distribution == "Debian" and ansible_distribution_major_version == 8
+    when: ansible_os_family == "Debian" and ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
     
   - name: Download Zabbix Debian 7 release deb file
     get_url: 
       url="http://repo.zabbix.com/zabbix/3.0/debian/pool/main/z/zabbix-release/zabbix-release_3.0-1+wheezy_all.deb"
       dest="/tmp/zabbix-release_3.0-1.deb"
-    when: ansible_os_family == "Debian" and ansible_distribution == "Debian" and ansible_distribution_major_version == 7
+    when: ansible_os_family == "Debian" and ansible_distribution == "Debian" and ansible_distribution_major_version == "7"
     
   - name: Download Zabbix Ubuntu 14 release deb file
     get_url: 


### PR DESCRIPTION
Conditionals set like this:

`ansible_distribution_major_version == 8`

will always fail, as the correct line is:

`ansible_distribution_major_version == "8"`

or

`ansible_distribution_major_version|int == 8`

It is set correctly for Ubuntu.
